### PR TITLE
fix: skip PR approval for premex-pot[bot] own PRs

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -46,7 +46,10 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
+      # Skip approval for premex-pot PRs — it can't approve its own PRs,
+      # and the org ruleset requires 0 approvals so it's not needed.
       - name: Approve PR
+        if: ${{ github.actor != 'premex-pot[bot]' }}
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
## Summary
- Skip the "Approve PR" step when the actor is `premex-pot[bot]` — GitHub doesn't allow an app to approve its own PR
- Syncs the fix already in `premex-ab/sync`

## Test plan
- [ ] Re-run the dependabot-automerge workflow on PR #9 after merging this